### PR TITLE
[task-2]  ALB Controller outputs

### DIFF
--- a/backlog/tasks/task-2 - Terraform EKS Fargate.md
+++ b/backlog/tasks/task-2 - Terraform EKS Fargate.md
@@ -33,6 +33,9 @@ Provision AWS infrastructure necessary for the “Team Notes” stack using Terr
 - 2025-08-01 15:25: Scaffolded complete directory structure and all required Terraform files for root and child modules per phase-1 scope.
 - 2025-08-01 15:36: Pushed branch and opened PR https://github.com/mrthehavok/k8s-advanced-webapp/pull/2
 - 2025-08-01 16:18: `terraform plan` and test `terraform apply` with dummy resource successful.
+- 2025-08-01 17:06: Pushed IRSA & Fargate phase branch and opened PR https://github.com/mrthehavok/k8s-advanced-webapp/pull/4
+
+- 2025-08-02 13:38: Phase-4: Added outputs for ALB Controller and cert-manager IRSA roles. Updated documentation.
 
 ## Decisions Made
 
@@ -66,6 +69,10 @@ Provision AWS infrastructure necessary for the “Team Notes” stack using Terr
 - infra/terraform/eks-fargate/modules/irsa/policies/cert-manager.json (created)
 - infra/terraform/eks-fargate/modules/irsa/policies/external-dns.json (created)
 - https://github.com/mrthehavok/k8s-advanced-webapp/pull/2 (pull request opened)
+- https://github.com/mrthehavok/k8s-advanced-webapp/pull/4 (pull request opened)
+- infra/terraform/eks-fargate/outputs.tf (updated)
+- docs/terraform-eks-design.md (updated)
+- infra/terraform/eks-fargate/README.md (updated)
 - backlog/tasks/task-2 - Terraform EKS Fargate.md (updated)
 
 ## Blockers

--- a/docs/terraform-eks-design.md
+++ b/docs/terraform-eks-design.md
@@ -282,6 +282,24 @@ output "kubeconfig_command" {
 }
 ```
 
+output "alb_controller_service_account" {
+description = "IRSA service account details for the AWS Load Balancer Controller"
+value = {
+namespace = "kube-system"
+name = "aws-load-balancer-controller"
+role_arn = lookup(module.irsa.role_arns, "alb-controller", null)
+}
+}
+
+output "cert_manager_service_account" {
+description = "IRSA service account details for cert-manager"
+value = {
+namespace = "cert-manager"
+name = "cert-manager"
+role_arn = lookup(module.irsa.role_arns, "cert-manager", null)
+}
+}
+
 ## 5. Backend Configuration
 
 ### backend.tf

--- a/infra/terraform/eks-fargate/README.md
+++ b/infra/terraform/eks-fargate/README.md
@@ -2,6 +2,10 @@
 
 This module provisions an AWS EKS cluster running entirely on Fargate profiles.
 
+## Prerequisites
+
+This stack assumes that the S3 bucket and DynamoDB table for the Terraform remote state backend have already been created. The `backend.tf` file is configured to use them, but they are not managed by this stack.
+
 ## Usage
 
 This is a root module designed to be deployed directly.

--- a/infra/terraform/eks-fargate/outputs.tf
+++ b/infra/terraform/eks-fargate/outputs.tf
@@ -52,6 +52,23 @@ output "irsa_role_arns" {
   value       = module.irsa.role_arns
 }
 
+output "alb_controller_service_account" {
+  description = "IRSA service account details for the AWS Load Balancer Controller"
+  value = {
+    namespace = "kube-system"
+    name      = "aws-load-balancer-controller"
+    role_arn  = lookup(module.irsa.role_arns, "alb-controller", null)
+  }
+}
+
+output "cert_manager_service_account" {
+  description = "IRSA service account details for cert-manager"
+  value = {
+    namespace = "cert-manager"
+    name      = "cert-manager"
+    role_arn  = lookup(module.irsa.role_arns, "cert-manager", null)
+  }
+}
 # Fargate Profile Outputs
 output "fargate_profile_names" {
   description = "List of Fargate profile names created for the cluster"


### PR DESCRIPTION
Phase-4:
• Abandons separate state-backend stack in favor of using existing backend config.
• Exposes ALB Controller & cert-manager service-account outputs from EKS stack.
• No resource changes in EKS plan; outputs only.
• terraform fmt / validate succeed in the stack.