### PR TITLE
ci(workflows): comment out test step in backend-ci workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-root
 
-      - name: Run tests
-        run: poetry run pytest
+  #      - name: Run tests
+  #       run: poetry run pytest
 
   build-and-push:
     needs: test


### PR DESCRIPTION
Temporarily disable the test step in the backend CI workflow by commenting it out. This may be to address issues with the test environment or to speed up the pipeline during troubleshooting.