### PR TITLE
ci(workflows): comment out build job dependencies in backend-ci workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -45,8 +45,8 @@ jobs:
   #       run: poetry run pytest
 
   build-and-push:
-    needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    #  needs: test
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Comment out the 'needs' and 'if' conditions for the build-and-push job to temporarily disable dependency on the test job and branch restriction.